### PR TITLE
Expose scrollToSpecificMessageById to message bubble

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,10 @@ The CometChat React Native UI Kit provides a pre-built user interface kit that d
 - Check the [Key Concepts](https://www.cometchat.com/docs/react-native-uikit/key-concepts) to understand the basic components of CometChat.
 - Refer to the [Integration Steps](https://www.cometchat.com/docs/react-native-uikit/integration) in our documentation to integrate the UI Kit into your React Native app.
 
+## Scrolling to a Message
+Each `CometChatMessageBubble` receives a `scrollToSpecificMessageById` prop from
+`CometChatMessageList`. Bubble components can call this function with a message
+ID to programmatically scroll the list and highlight the desired message.
+
 ## Help and Support
 For issues running the project or integrating with our UI Kits, consult our [documentation](https://www.cometchat.com/docs/react-native-uikit/integration) or create a [support ticket](https://help.cometchat.com/hc/en-us) or seek real-time support via the [CometChat Dashboard](https://app.cometchat.com/).

--- a/src/AI/AIAssistBot/AIAssistBotView.tsx
+++ b/src/AI/AIAssistBot/AIAssistBotView.tsx
@@ -20,7 +20,8 @@ interface AIAssistBotViewProps {
     closeCallback: () => void,
     bot: CometChat.User,
     sender: CometChat.User | any,
-    onSend: (question: string, bot: CometChat.User) => Promise<any>
+    onSend: (question: string, bot: CometChat.User) => Promise<any>,
+    scrollToSpecificMessageById?: (messageId: string | number) => void
 }
 
 const AIAssistBotView = (props: AIAssistBotViewProps) => {
@@ -233,6 +234,7 @@ const AIAssistBotView = (props: AIAssistBotViewProps) => {
                     FooterView={() => getFooterView(item, getBubbleAlignment(item, sender))}
                     alignment={getBubbleAlignment(item, sender)}
                     style={getMessageBubbleStyle(item, theme, sender, configuration)}
+                    scrollToSpecificMessageById={props.scrollToSpecificMessageById}
                 />
             </View>
         )

--- a/src/CometChatMessageList/CometChatMessageList.tsx
+++ b/src/CometChatMessageList/CometChatMessageList.tsx
@@ -4,6 +4,7 @@ import { View, FlatList, Text, Image, TouchableOpacity, ActivityIndicator, Modal
 import { CometChat } from "@cometchat/chat-sdk-react-native";
 import { LeftArrowCurve, RightArrowCurve } from "./resources";
 import { CometChatContext, CometChatMentionsFormatter, CometChatTextFormatter, CometChatUIKit, CometChatUiKitConstants, CometChatUrlsFormatter, ImageType, SuggestionItem } from "../shared";
+import { createScrollToSpecificMessageById } from "./scrollUtils";
 import { MessageBubbleStyle, MessageBubbleStyleInterface } from "../shared/views/CometChatMessageBubble/MessageBubbleStyle";
 import { AvatarStyle, AvatarStyleInterface } from "../shared";
 import { CometChatAvatar, CometChatDate, CometChatReceipt, DateStyle } from "../shared";
@@ -874,35 +875,11 @@ export const CometChatMessageList = memo(forwardRef<
         }
 
 
-        // Replace your scrollToSpecificMessageById function with this:
-        const scrollToSpecificMessageById = (messageId : any) => {
-        
-        const messageRef = messageRefs.current.get(messageId);
-        
-        if (messageRef && messageListRef.current) {
-
-            // Highlight the message
-            setHighlightedMessageId(messageId);
-
-            messageRef.measureLayout(
-            messageListRef.current.getInnerViewNode(),
-            (x: any, y: number, width: any, height: any) => {
-                messageListRef.current!.scrollTo({
-                y: Math.max(0, y - 20), // 20px offset from top
-                animated: true
-                });
-            },
-            (error : any) => {
-                console.error('Failed to measure message layout:', error);
-            }
-            );
-
-            // Remove highlight after 3 seconds
-            setTimeout(() => {
-            setHighlightedMessageId(null);
-            }, 1500);
-          }
-        };
+        const scrollToSpecificMessageById = createScrollToSpecificMessageById(
+            messageRefs,
+            messageListRef,
+            setHighlightedMessageId,
+        );
 
         const handlePannel = (item: any) => {
             if (item.alignment === ViewAlignment.messageListBottom && (user || group) && CommonUtils.checkIdBelongsToThisComponent(item.id, user, group, parentMessageId || '')) {
@@ -1767,6 +1744,7 @@ export const CometChatMessageList = memo(forwardRef<
                         BottomView={hasTemplate.BottomView && hasTemplate.BottomView?.bind(this, message, bubbleAlignment)}
                         StatusInfoView={hasTemplate.StatusInfoView ? hasTemplate.StatusInfoView?.bind(this, message, bubbleAlignment) : () => getStatusInfoView(message, bubbleAlignment, currentIndex)}
                         style={getStyle(message)}
+                        scrollToSpecificMessageById={scrollToSpecificMessageById}
                     />
                 </TouchableOpacity>
             } else {

--- a/src/CometChatMessageList/__tests__/scrollUtils.test.ts
+++ b/src/CometChatMessageList/__tests__/scrollUtils.test.ts
@@ -1,0 +1,23 @@
+import { createScrollToSpecificMessageById } from '../scrollUtils';
+
+describe('createScrollToSpecificMessageById', () => {
+  test('invokes scrollTo on the provided list ref', () => {
+    const measureLayout = jest.fn((_node: any, callback: any) => callback(0, 50, 0, 0));
+    const scrollTo = jest.fn();
+    const messageRefs = { current: new Map<any, any>([['1', { measureLayout }]]) } as any;
+    const messageListRef = { current: { getInnerViewNode: () => ({}), scrollTo } } as any;
+    const setHighlighted = jest.fn();
+
+    const scrollToSpecificMessageById = createScrollToSpecificMessageById(
+      messageRefs,
+      messageListRef,
+      setHighlighted,
+    );
+
+    scrollToSpecificMessageById('1');
+
+    expect(measureLayout).toHaveBeenCalled();
+    expect(scrollTo).toHaveBeenCalled();
+    expect(setHighlighted).toHaveBeenCalledWith('1');
+  });
+});

--- a/src/CometChatMessageList/scrollUtils.ts
+++ b/src/CometChatMessageList/scrollUtils.ts
@@ -1,0 +1,32 @@
+/**
+ * Utility to generate a scroll handler that scrolls the message list to
+ * a specific message and briefly highlights it. The handler can be passed
+ * down to message bubble components so they can trigger scrolling on demand.
+ */
+export const createScrollToSpecificMessageById = (
+    messageRefs: React.MutableRefObject<Map<any, any>>,
+    messageListRef: React.RefObject<any>,
+    setHighlightedMessageId: (id: any | null) => void
+) => {
+    return (messageId: any) => {
+        const messageRef = messageRefs.current.get(messageId);
+        if (messageRef && messageListRef.current) {
+            setHighlightedMessageId(messageId);
+            messageRef.measureLayout(
+                messageListRef.current.getInnerViewNode(),
+                (x: number, y: number, width: number, height: number) => {
+                    messageListRef.current!.scrollTo({
+                        y: Math.max(0, y - 20),
+                        animated: true,
+                    });
+                },
+                (error: any) => {
+                    console.error('Failed to measure message layout:', error);
+                }
+            );
+            setTimeout(() => {
+                setHighlightedMessageId(null);
+            }, 1500);
+        }
+    };
+};

--- a/src/shared/utils/MessageUtils.tsx
+++ b/src/shared/utils/MessageUtils.tsx
@@ -15,6 +15,7 @@ type MessageViewType = {
     template?: CometChatMessageTemplate,
     alignment?: MessageBubbleAlignmentType,
     theme?: CometChatTheme,
+    scrollToSpecificMessageById?: (messageId: string | number) => void,
 }
 //TODO: Need to restructure
 const MessageContentView = (props: { message: CometChat.BaseMessage, alignment?: MessageBubbleAlignmentType, theme?: CometChatTheme }):JSX.Element | any => {
@@ -64,6 +65,7 @@ export const MessageUtils = {
             ContentView={template?.ContentView ? () => template?.ContentView ? template?.ContentView(message, alignment) : null : () => MessageContentView({message,alignment,theme})}
             BottomView={template?.BottomView && template?.BottomView?.bind(this, message, alignment)}
             style={getStyle(message)}
+            scrollToSpecificMessageById={params.scrollToSpecificMessageById}
         />;
     },
 

--- a/src/shared/views/CometChatMessageBubble/CometChatMessageBubble.tsx
+++ b/src/shared/views/CometChatMessageBubble/CometChatMessageBubble.tsx
@@ -62,6 +62,10 @@ export interface CometChatMessageBubbleInterface {
      * @type BaseStyleInterface
      */
     style?: MessageBubbleStyleInterface,
+    /**
+     * Function to scroll the list to a specific message id
+     */
+    scrollToSpecificMessageById?: (messageId: string | number) => void,
 }
 
 export const CometChatMessageBubble = memo(({
@@ -75,7 +79,8 @@ export const CometChatMessageBubble = memo(({
     ThreadView,
     alignment = 'left',
     id,
-    style
+    style,
+    scrollToSpecificMessageById
 }: CometChatMessageBubbleInterface ) => {
 
     const {theme} = useContext<CometChatContextType>(CometChatContext);


### PR DESCRIPTION
## Summary
- add scroll utilities helper
- wire up scroll handler in `CometChatMessageList`
- allow `CometChatMessageBubble` to accept `scrollToSpecificMessageById`
- pass new prop from message list and assist bot view
- mention handler in README
- add unit test for scroll helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a453d5bc8324bf1c07aff2d72b03