### PR TITLE
Close message options when sharing a message

### DIFF
--- a/src/CometChatMessageList/CometChatMessageList.tsx
+++ b/src/CometChatMessageList/CometChatMessageList.tsx
@@ -1578,6 +1578,7 @@ export const CometChatMessageList = memo(forwardRef<
         }
 
         const shareMedia = async (messageObject: CometChat.MediaMessage | any) => {
+            setShowMessageOptions([]);
             let _plainString = getPlainString(messageObject?.getData()['text'] || "", messageObject);
 
             let textMessage = _plainString;


### PR DESCRIPTION
## Summary
- close the message options sheet before triggering the native share action so the bottom sheet dismisses after sharing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904661030e88324aa302f40f1a90612